### PR TITLE
feat: add isSquare prop to enable square icons

### DIFF
--- a/src/component.jsx
+++ b/src/component.jsx
@@ -87,6 +87,7 @@ export const SocialIcon = React.forwardRef(function SocialIcon(props, ref) {
     children,
     fallback,
     defaultSVG,
+    isSquare = false,
     ...rest
   } = props
 
@@ -119,7 +120,7 @@ export const SocialIcon = React.forwardRef(function SocialIcon(props, ref) {
         aria-label={`${ariaLabel} social icon`}
         className="social-svg"
         viewBox="0 0 64 64"
-        style={social_svg}
+        style={{ ...social_svg, borderRadius: isSquare ? 0 : '50%' }}
       >
         <g
           className="social-svg-icon"

--- a/src/component.jsx
+++ b/src/component.jsx
@@ -39,6 +39,14 @@ const makeUriRegex = (socials = []) =>
     'u',
   )
 
+const getSvgStyle = (square = false) => {
+  const style = { ...social_svg }
+  if (square) {
+    style.borderRadius = 0
+  }
+  return style
+}
+
 export const social_icons = new Map()
 export const network_names = new Set()
 export let uri_regex = makeUriRegex()
@@ -87,12 +95,13 @@ export const SocialIcon = React.forwardRef(function SocialIcon(props, ref) {
     children,
     fallback,
     defaultSVG,
-    isSquare = false,
+    square = false,
     ...rest
   } = props
 
   const networkKey = network || networkFor(url)
   const ariaLabel = label || props['aria-label'] || networkKey
+  const svgStyle = getSvgStyle(square)
 
   const fallbackIcon =
     (typeof fallback === 'string'
@@ -120,7 +129,7 @@ export const SocialIcon = React.forwardRef(function SocialIcon(props, ref) {
         aria-label={`${ariaLabel} social icon`}
         className="social-svg"
         viewBox="0 0 64 64"
-        style={{ ...social_svg, borderRadius: isSquare ? 0 : '50%' }}
+        style={svgStyle}
       >
         <g
           className="social-svg-icon"

--- a/src/react-social-icons.d.ts
+++ b/src/react-social-icons.d.ts
@@ -20,7 +20,7 @@ interface SocialIconProps
   defaultSVG?: SocialIconObject
   style?: React.CSSProperties
   as?: string
-  isSquare?: boolean
+  square?: boolean
 }
 
 declare function networkFor(url?: string): string

--- a/src/react-social-icons.d.ts
+++ b/src/react-social-icons.d.ts
@@ -20,6 +20,7 @@ interface SocialIconProps
   defaultSVG?: SocialIconObject
   style?: React.CSSProperties
   as?: string
+  isSquare?: boolean
 }
 
 declare function networkFor(url?: string): string

--- a/test/typescript/SocialIcon.tsx
+++ b/test/typescript/SocialIcon.tsx
@@ -21,6 +21,7 @@ const SocialIconTest = () => (
       target="blank"
       rel="noreferrer"
       as="div"
+      isSquare
     />
     <SocialIcon
       // @ts-expect-error
@@ -51,6 +52,10 @@ const SocialIconTest = () => (
     <SocialIcon>
       <div></div>
     </SocialIcon>
+
+    <SocialIcon url="https://example.com" isSquare={true} />
+    {/* @ts-expect-error: isSquare should be a boolean */}
+    <SocialIcon url="https://example.com" isSquare="true" />
   </>
 )
 

--- a/test/typescript/SocialIcon.tsx
+++ b/test/typescript/SocialIcon.tsx
@@ -21,7 +21,7 @@ const SocialIconTest = () => (
       target="blank"
       rel="noreferrer"
       as="div"
-      isSquare
+      square
     />
     <SocialIcon
       // @ts-expect-error
@@ -53,9 +53,9 @@ const SocialIconTest = () => (
       <div></div>
     </SocialIcon>
 
-    <SocialIcon url="https://example.com" isSquare={true} />
-    {/* @ts-expect-error: isSquare should be a boolean */}
-    <SocialIcon url="https://example.com" isSquare="true" />
+    <SocialIcon url="https://example.com" square={true} />
+    {/* @ts-expect-error: square should be a boolean */}
+    <SocialIcon url="https://example.com" square="true" />
   </>
 )
 

--- a/test/unit/cases.js
+++ b/test/unit/cases.js
@@ -320,15 +320,15 @@ export const cases = ({ SocialIcon, getKeys }) =>
       expect(link().querySelector('div')).toBeNull()
     })
 
-    it('renders circular icon by default when isSquare is not provided', ({
+    it('renders circular icon by default when square is not provided', ({
       expect,
     }) => {
       render(<SocialIcon url={pinterest_url} />)
       expect(svg()).toHaveStyle('borderRadius: 50%')
     })
 
-    it('renders square icon when isSquare prop is true', ({ expect }) => {
-      render(<SocialIcon url={pinterest_url} isSquare />)
+    it('renders square icon when square prop is true', ({ expect }) => {
+      render(<SocialIcon url={pinterest_url} square />)
       expect(svg()).toHaveStyle('borderRadius: 0')
     })
   })

--- a/test/unit/cases.js
+++ b/test/unit/cases.js
@@ -319,4 +319,16 @@ export const cases = ({ SocialIcon, getKeys }) =>
       render(<SocialIcon url={pinterest_url} />)
       expect(link().querySelector('div')).toBeNull()
     })
+
+    it('renders circular icon by default when isSquare is not provided', ({
+      expect,
+    }) => {
+      render(<SocialIcon url={pinterest_url} />)
+      expect(svg()).toHaveStyle('borderRadius: 50%')
+    })
+
+    it('renders square icon when isSquare prop is true', ({ expect }) => {
+      render(<SocialIcon url={pinterest_url} isSquare />)
+      expect(svg()).toHaveStyle('borderRadius: 0')
+    })
   })

--- a/test/visual/spec.jsx
+++ b/test/visual/spec.jsx
@@ -50,14 +50,8 @@ function VisualTest(props) {
 
       {highlighted && <HighlightCase network={highlighted} />}
 
-      <h2>Default Icons</h2>
       {networks.map((network) => (
         <Case key={network} network={network} />
-      ))}
-
-      <h2>Square Icons</h2>
-      {networks.map((network) => (
-        <SquareCase key={`square-${network}`} network={network} />
       ))}
     </div>
   )
@@ -132,59 +126,6 @@ function HighlightCase(props) {
       </div>
       <div className="xl">
         <SocialIcon network={network} style={xl} />
-      </div>
-    </section>
-  )
-}
-
-function SquareCase(props) {
-  const { network } = props
-
-  return (
-    <section className={`${network} square`}>
-      <div className="sm">
-        <SocialIcon network={network} style={sm} isSquare />
-        <SocialIcon
-          network={network}
-          style={sm}
-          isSquare
-          fgColor={social_icons.get(network).color}
-          bgColor="white"
-        />
-        <SocialIcon
-          network={network}
-          style={sm}
-          isSquare
-          fgColor="transparent"
-        />
-        <SocialIcon
-          network={network}
-          style={sm}
-          isSquare
-          bgColor="transparent"
-        />
-      </div>
-      <div className="lg">
-        <SocialIcon network={network} style={lg} isSquare />
-        <SocialIcon
-          network={network}
-          style={lg}
-          isSquare
-          fgColor={social_icons.get(network).color}
-          bgColor="white"
-        />
-        <SocialIcon
-          network={network}
-          style={lg}
-          isSquare
-          fgColor="transparent"
-        />
-        <SocialIcon
-          network={network}
-          style={lg}
-          isSquare
-          bgColor="transparent"
-        />
       </div>
     </section>
   )

--- a/test/visual/spec.jsx
+++ b/test/visual/spec.jsx
@@ -50,8 +50,14 @@ function VisualTest(props) {
 
       {highlighted && <HighlightCase network={highlighted} />}
 
+      <h2>Default Icons</h2>
       {networks.map((network) => (
         <Case key={network} network={network} />
+      ))}
+
+      <h2>Square Icons</h2>
+      {networks.map((network) => (
+        <SquareCase key={`square-${network}`} network={network} />
       ))}
     </div>
   )
@@ -126,6 +132,59 @@ function HighlightCase(props) {
       </div>
       <div className="xl">
         <SocialIcon network={network} style={xl} />
+      </div>
+    </section>
+  )
+}
+
+function SquareCase(props) {
+  const { network } = props
+
+  return (
+    <section className={`${network} square`}>
+      <div className="sm">
+        <SocialIcon network={network} style={sm} isSquare />
+        <SocialIcon
+          network={network}
+          style={sm}
+          isSquare
+          fgColor={social_icons.get(network).color}
+          bgColor="white"
+        />
+        <SocialIcon
+          network={network}
+          style={sm}
+          isSquare
+          fgColor="transparent"
+        />
+        <SocialIcon
+          network={network}
+          style={sm}
+          isSquare
+          bgColor="transparent"
+        />
+      </div>
+      <div className="lg">
+        <SocialIcon network={network} style={lg} isSquare />
+        <SocialIcon
+          network={network}
+          style={lg}
+          isSquare
+          fgColor={social_icons.get(network).color}
+          bgColor="white"
+        />
+        <SocialIcon
+          network={network}
+          style={lg}
+          isSquare
+          fgColor="transparent"
+        />
+        <SocialIcon
+          network={network}
+          style={lg}
+          isSquare
+          bgColor="transparent"
+        />
       </div>
     </section>
   )


### PR DESCRIPTION
#401  This pull request introduces a new boolean prop, **isSquare**, to the SocialIcon component. With this prop, users can easily choose to render square icons instead of the default circular ones.


<img width="1008" alt="Screenshot 2025-02-18 at 9 54 18 PM" src="https://github.com/user-attachments/assets/7e7e4452-5857-4443-80bc-b714b35200ba" />

<img width="485" alt="Screenshot 2025-02-18 at 9 52 33 PM" src="https://github.com/user-attachments/assets/a0c7e65d-58d2-46e9-aba8-71d4153d143a" />
